### PR TITLE
Fix index out of range

### DIFF
--- a/pubsub/subscribe.go
+++ b/pubsub/subscribe.go
@@ -78,12 +78,17 @@ func (c Client) On(topic string, f Handler, deadline time.Duration, autoAck bool
 			oV = []reflect.Value{reflect.ValueOf(c), reflect.ValueOf(m.Metadata), obj}
 		}
 
-		errInterface := handler.Call(oV)[0].Interface()
+		returnVal := handler.Call(oV)
+		if len(returnVal) == 0 {
+			return nil
+		}
+
+		errInterface := returnVal[0].Interface()
 		if errInterface == nil {
 			return nil
-		} else {
-			return errInterface.(error)
 		}
+
+		return errInterface.(error)
 	}
 
 	c.Provider.Subscribe(topic, cb, deadline, autoAck)


### PR DESCRIPTION
I get this error on the subscriber side when a message is received. 

```
panic: runtime error: index out of range

goroutine 132 [running]:
github.com/lileio/lile/pubsub.Client.On.func2(0x1927b60, 0xc4203ba8a0, 0xc4203f2570, 0xf, 0xc4203ba720, 0xc4203f23d0, 0xa, 0xa, 0xc4203f2680, 0xc4203f2690, ...)
        /Users/baopham/Projects/Go/src/github.com/lileio/lile/pubsub/subscribe.go:81 +0x2b8
github.com/lileio/lile/pubsub/google.(*GoogleCloud).subscribe.func1.1(0x1fa5910, 0xc4203ba8a0, 0xc420246850)
        /Users/baopham/Projects/Go/src/github.com/lileio/lile/pubsub/google/google.go:160 +0x575
cloud.google.com/go/pubsub.(*Subscription).receive.func2(0xc4203d8f30, 0xc420409000, 0xc420246850, 0xc420388660, 0x1c90fc0, 0xc42034af00)
        /Users/baopham/Projects/Go/src/cloud.google.com/go/pubsub/subscription.go:392 +0xa2
created by cloud.google.com/go/pubsub.(*Subscription).receive
        /Users/baopham/Projects/Go/src/cloud.google.com/go/pubsub/subscription.go:393 +0x311
exit status 2
```

My subscriber is standard following README example https://github.com/lileio/lile#subscribing-to-events