### PR TITLE
Fix projectBase()

### DIFF
--- a/lile/cmd/project.go
+++ b/lile/cmd/project.go
@@ -130,7 +130,11 @@ func projectPath(inputPath string) string {
 }
 
 func projectBase(absPath string) string {
-	return lastFromSplit(filepath.ToSlash(absPath), filepath.ToSlash(srcPath()))
+	rel, err := filepath.Rel(srcPath(), absPath)
+	if err != nil {
+		return filepath.ToSlash(absPath)
+	}
+	return filepath.ToSlash(rel)
 }
 
 func lastFromSplit(input, split string) string {


### PR DESCRIPTION
On case-insensitive systems such as Windows, projectBase (path) sometimes fails.
Specifically, it occurs when GOPATH and absPath do not match.
It is better to use filepath.Rel () to absorb the differences by the system.

```
# GOPATH and absPath do not match (ex `c:\` vs `C:\`)
$GOPATH
    -> c:\Users\xxx\dev
srcPath()
    -> c:\Users\xxx\dev\src\
projectBase(C:\Users\xxx\dev\src\github.com\lileio\xyz4)
    -> C:/Users/xxx/dev/src/github.com/lileio/xyz4
```

```
# GOPATH and absPath match
$GOPATH
    -> C:\Users\xxx\dev
srcPath()
    -> C:\Users\xxx\dev\src\
projectBase(C:\Users\xxx\dev\src\github.com\lileio\xyz4)
    -> C:/Users/xxx/dev/src/github.com/lileio/xyz4
```


