### PR TITLE
Fix usage of uuid.NewV1()

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -259,8 +259,7 @@
 [[projects]]
   name = "github.com/satori/go.uuid"
   packages = ["."]
-  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
-  version = "v1.2.0"
+  revision = "36e9d2ebbde5e3f13ab2e25625fd453271d6522e"
 
 [[projects]]
   branch = "master"
@@ -455,6 +454,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "96799119b10f7f0c5c77f2c778332c4e3cc8b9acae3176bd8fcfccbe90435870"
+  inputs-digest = "2d1f01cf714e508ab28de00647db7926c47bb75820cddf29467d2ad7223adbd0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -71,7 +71,7 @@
 
 [[constraint]]
   name = "github.com/satori/go.uuid"
-  version = "1.2.0"
+  revision = "36e9d2ebbde5e3f13ab2e25625fd453271d6522e"
 
 [[constraint]]
   branch = "master"

--- a/lile.go
+++ b/lile.go
@@ -115,8 +115,12 @@ func CreateServer() *grpc.Server {
 // it returns the socket location and a func to call which starts the server
 func NewTestServer(s *grpc.Server) (string, func()) {
 	// Create a temp random unix socket
-	uid := uuid.NewV1().String()
-	skt := "/tmp/" + uid
+	uid, err := uuid.NewV1()
+	if err != nil {
+		panic(err)
+	}
+
+	skt := "/tmp/" + uid.String()
 
 	ln, err := net.Listen("unix", skt)
 	if err != nil {


### PR DESCRIPTION
Was getting this error when trying to update. Not sure how tests are passing on CI though... 😕 

```
Jons-MacBook-Pro:lile jonbretman$ go get -u github.com/lileio/lile
# github.com/lileio/lile
../lile/lile.go:118:19: multiple-value uuid.NewV1() in single-value context
```
