### PR TITLE
#37 Add windows test transport support

### DIFF
--- a/lile.go
+++ b/lile.go
@@ -113,31 +113,33 @@ func CreateServer() *grpc.Server {
 
 //   Creates a server listener dependent on the underlying platform. Windows
 // hosts will have a Windows Named pipe, anything else gets a UNIX socket
-func getTestServerTransportOrPanic()(string, net.Listener) {
+func getTestServerTransport()(string, net.Listener, error) {
 	var uniqueAddress string
 
-	// Create a temp random unix socket
+	// Create a random string for part of the address
 	uid, err := uuid.NewV1()
 	if err != nil {
-		panic(err)
+		return "", nil, err
 	}
+
 	uniqueAddress = formatPlatformTestSeverAddress(uid.String())
 
 	serverListener, err := getTestServerListener(uniqueAddress)
-
 	if err != nil {
-		panic(err)
+		return "", nil, err
 	}
 
-	return uniqueAddress, serverListener
+	return uniqueAddress, serverListener, nil
 }
 
 //   NewTestServer is a helper function to create a gRPC server on a non-network
 // socket and it returns the socket location and a func to call which starts
 // the server
 func NewTestServer(s *grpc.Server) (string, func()) {
-
-	socketAddress, listener := getTestServerTransportOrPanic()
+	socketAddress, listener, err := getTestServerTransport()
+	if err != nil {
+		panic(err)
+	}
 
 	return socketAddress, func() {
 		s.Serve(listener)

--- a/lile_unix.go
+++ b/lile_unix.go
@@ -1,1 +1,19 @@
+// +build !windows
+
 package lile
+
+import (
+	"net"
+)
+
+func formatPlatformTestSeverAddress(uniquePortion string)(string) {
+	return "/tmp/" + uniquePortion
+}
+
+func getTestServerListener(address string)(net.Listener, error) {
+	return net.Listen("unix", address)
+}
+
+func dialTestServer(address string)(net.Conn, error) {
+	return  net.Dial("unix", address)
+}

--- a/lile_unix.go
+++ b/lile_unix.go
@@ -1,0 +1,1 @@
+package lile

--- a/lile_windows.go
+++ b/lile_windows.go
@@ -1,1 +1,20 @@
+// +build windows
+
 package lile
+
+import (
+	"github.com/natefinch/npipe"
+	"net"
+)
+
+func formatPlatformTestSeverAddress(uniquePortion string)(string) {
+	return `\\.\pipe\` + uniquePortion
+}
+
+func getTestServerListener(address string)(net.Listener, error) {
+	return npipe.Listen(address)
+}
+
+func dialTestServer(address string)(net.Conn, error) {
+	return  npipe.Dial(address)
+}

--- a/lile_windows.go
+++ b/lile_windows.go
@@ -1,0 +1,1 @@
+package lile


### PR DESCRIPTION
* Uses named pipes for new test gRPC servers and clients