### PR TITLE
Set lile port from PORT environment variable

### DIFF
--- a/lile.go
+++ b/lile.go
@@ -34,9 +34,13 @@ type Service struct {
 }
 
 func defaultOptions(n string) Service {
+	port := ":8000"
+	if p := os.Getenv("PORT"); p != "" {
+		port = p
+	}
 	return Service{
 		Name:               n,
-		Port:               ":8000",
+		Port:               port,
 		GRPCImplementation: func(s *grpc.Server) {},
 	}
 }


### PR DESCRIPTION
Considering that the default port for Prometheus is read from `PROMETHEUS_PORT` environment variable, we found it would be useful if the default Lile server did the same using the `PORT` environment variable.