### PR TITLE
Switch to gofrs/uuid package

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"google.golang.org/grpc"
 )
 


### PR DESCRIPTION
Seeing the inactivity of the satori/go.uuid repository, a group of Go developers has stepped up to maintain it, fixing a few issues. It does not cost much, and also improves Lile. :sparkles: 

See also: https://github.com/satori/go.uuid/issues/84