### PR TITLE
Use go/build.Default.GOPATH

### DIFF
--- a/lile/cmd/new.go
+++ b/lile/cmd/new.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"bufio"
 	"fmt"
+	"go/build"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -27,15 +27,7 @@ var (
 var out = colorable.NewColorableStdout()
 
 func init() {
-	gopath = os.Getenv("GOPATH")
-	if gopath == "" {
-		b, err := exec.Command("go", "env", "GOPATH").CombinedOutput()
-		if err != nil {
-			panic(string(b))
-		}
-		gopath = strings.TrimSpace(string(b))
-	}
-
+	gopath := build.Default.GOPATH
 	if paths := filepath.SplitList(gopath); len(paths) > 0 {
 		gopath = paths[0]
 	}

--- a/protoc-gen-lile-server/main.go
+++ b/protoc-gen-lile-server/main.go
@@ -3,12 +3,12 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"go/build"
 	"go/format"
 	"io"
 	"io/ioutil"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -57,14 +57,7 @@ type goimport struct {
 }
 
 func init() {
-	gopath = os.Getenv("GOPATH")
-	if gopath == "" {
-		b, err := exec.Command("go", "env", "GOPATH").CombinedOutput()
-		if err != nil {
-			panic(string(b))
-		}
-		gopath = strings.TrimSpace(string(b))
-	}
+	gopath = build.Default.GOPATH
 	if paths := filepath.SplitList(gopath); len(paths) > 0 {
 		gopath = paths[0]
 	}


### PR DESCRIPTION
Better way to recognize GOPATH instead of `go env GOPATH`.