### PR TITLE
Fix the 'up' command in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -284,7 +284,7 @@ For example `go run orders/main.go`
 ### up
 Running `up` will run both the RPC server and the pubsub subscribers.
 
-```go run orders/main.go```
+```go run orders/main.go up```
 
 ## Adding your own cmds
 


### PR DESCRIPTION
As I was trying out the lile I noticed that the 'up' command in the readme was incorrect. This commit fixes the command.